### PR TITLE
Fix overflow vulnerability in rule-file argument

### DIFF
--- a/scanner.c
+++ b/scanner.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <linux/limits.h>
 #include "yara.h"
 
 void showUsage( const char* prog )
@@ -85,7 +86,7 @@ int main( int argc, char* argv[] )
                 free( szRulePath );
                 exit( EXIT_FAILURE );
             }
-            szRulePath = strdup( optarg );
+            szRulePath = strndup( optarg, PATH_MAX );
             break;
         case 'h': // help
         default:


### PR DESCRIPTION
~~Stack~~ overflow vulnerability when doing `strdup` of argument. 

Exploited by doing something like `build/scanner -r $(python -c "print('a' * 9999999)")`

Fixed with `strndup`, giving it linux's max length of a file's path (4096 on my system), found in `linux/limits.h`. 

EDIT: Not stack, of course. `strdup` allocates to heap