### PR TITLE
Add a routine for handling exception  explicitly in "initYara" function.

### DIFF
--- a/scanner.c
+++ b/scanner.c
@@ -98,7 +98,7 @@ int main( int argc, char* argv[] )
         fprintf( stderr, "Rule file is not given.\n" );
         return EXIT_FAILURE;
     } else {
-        initYara( szRulePath, &rules );
+        if ( initYara( szRulePath, &rules ) == -1 ) exit(1);
     }
 
     if ( optind >= argc ) scanProcs( rules );


### PR DESCRIPTION
Since there is no exit routine when an error occurs in initYara , I added it.

The scanner code itself does not make any fault. However, if anyone tries to add and access their rules after any error occurs (I.e. Return value of initYara function is -1), segmentation faults will occur.